### PR TITLE
Expose port 4000 to the host with the jekyll alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sudo docker run --rm -v "$PWD:/src" grahamc/jekyll build
 or for repeated calls:
 
 ```
-alias jekyll='sudo docker run --rm -v "$PWD:/src" grahamc/jekyll'
+alias jekyll='sudo docker run --rm -v "$PWD:/src" -p 4000:4000 grahamc/jekyll'
 jekyll build
 jekyll serve
 ```


### PR DESCRIPTION
Currently the jekyll alias proposed in the readme doesn't map the port 4000 to the host. I propose exposing port 4000 to the host in the alias by default.
