### PR TITLE
docker run "--rm" & "-d" options don't work together

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jekyll serve
 
 run as a background daemon:
 ```
-sudo docker run -d --rm -v "$PWD:/src" -p 4000:4000 grahamc/jekyll serve
+sudo docker run -d -v "$PWD:/src" -p 4000:4000 grahamc/jekyll serve
 ```
 
 ## Goodies


### PR DESCRIPTION
docker 1.3.0 says: Conflicting options: --rm and -d
