### PR TITLE
Fix node.js package name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER graham@grahamc.com
 
 RUN apt-get update \
   && apt-get install -y \
-    node \
+    nodejs \
     python-pygments \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
Debian package for node.js is "nodejs". The "node" package has nothing to do with node.js.
