### PR TITLE
Use `bundle exec jekyll` as ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ VOLUME /src
 EXPOSE 4000
 
 WORKDIR /src
-ENTRYPOINT ["jekyll"]
+ENTRYPOINT ["bundle", "exec", "jekyll"]
 


### PR DESCRIPTION
In response to apparent gem incompatibilities when using a bare `jekyll` command,
reported in several issues on the jekyll/jekyll repository, the ENTRYPOINT is changed
to ["bundle", "exec", "jekyll"], which resolves the problem.

Fixes #22

Signed-off-by: Aaron Browne aaron0browne@gmail.com
