### PR TITLE
added latest nodejs and npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ RUN apt-get update \
     python-pygments \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/
+  
+RUN apt-get install --yes curl
+RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install --yes nodejs
+RUN apt-get install --yes build-essential
 
 RUN gem install \
   github-pages \


### PR DESCRIPTION
When comparing to Jekyll's official docker images, I noticed that nodejs and npm were present. However, for this one, they were absent. To fulfil the ideal of being the ubuntu version of the jekyll/jekyll, I've added nodejs and npm (distinct from node installed above).
